### PR TITLE
Mejoras de usabilidad para los tests del lab shell

### DIFF
--- a/fork/run
+++ b/fork/run
@@ -8,5 +8,5 @@ fi;
 LAB_PATH=$1
 shift
 
-docker build -t test-runner -f Dockerfile .
-docker run -v $LAB_PATH:/fork/lab-under-test test-runner ./test-fork /fork/lab-under-test $@
+docker build -t test-fork-runner -f Dockerfile .
+docker run -v $LAB_PATH:/fork/lab-under-test test-fork-runner ./test-fork /fork/lab-under-test $@

--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -2,9 +2,9 @@ FROM ubuntu:20.04
 
 RUN apt-get update && apt-get install -y make gcc build-essential gcc-multilib python3.8 python3-pip time
 
-#RUN adduser --disabled-login --disabled-password fisop
-#USER fisop
-#ENV PATH="/home/fisop/.local/bin:${PATH}"
+RUN adduser --disabled-login --disabled-password fisop
+USER fisop
+ENV PATH="/home/fisop/.local/bin:${PATH}"
 
 RUN pip install termcolor pyyaml
 

--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:20.04
 
-RUN apt-get update && apt-get install -y make gcc build-essential gcc-multilib
+RUN apt-get update && apt-get install -y make gcc build-essential gcc-multilib python3.8 python3-pip
 
-RUN adduser -D fisop
+RUN adduser --disabled-login --disabled-password fisop
 USER fisop
 ENV PATH="/home/fisop/.local/bin:${PATH}"
 

--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:20.04
+
+RUN apt-get update && apt-get install -y make gcc build-essential gcc-multilib
+
+RUN adduser -D fisop
+USER fisop
+ENV PATH="/home/fisop/.local/bin:${PATH}"
+
+RUN pip install termcolor pyyaml
+
+WORKDIR /shell
+
+ENV TARGET_SHELL=/shell/lab-to-test
+
+COPY . .

--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -1,15 +1,15 @@
 FROM ubuntu:20.04
 
-RUN apt-get update && apt-get install -y make gcc build-essential gcc-multilib python3.8 python3-pip
+RUN apt-get update && apt-get install -y make gcc build-essential gcc-multilib python3.8 python3-pip time
 
-RUN adduser --disabled-login --disabled-password fisop
-USER fisop
-ENV PATH="/home/fisop/.local/bin:${PATH}"
+#RUN adduser --disabled-login --disabled-password fisop
+#USER fisop
+#ENV PATH="/home/fisop/.local/bin:${PATH}"
 
 RUN pip install termcolor pyyaml
 
 WORKDIR /shell
 
-ENV TARGET_SHELL=/shell/lab-to-test
+ENV TARGET_SHELL_DIR=/shell/lab-to-test
 
 COPY . .

--- a/shell/Makefile
+++ b/shell/Makefile
@@ -1,13 +1,22 @@
-TARGET_SHELL ?= /bin/bash
+TARGET_SHELL ?=
 REFLECTOR ?= $(abspath ./reflector)
 
 all: reflector
 
-test: reflector
+compile-target-shell: check-env
+	$(MAKE) -C $(TARGET_SHELL) clean
+	$(MAKE) -C $(TARGET_SHELL) 
+
+test: check-env reflector compile-target-shell
 	./test-shell.py $(TARGET_SHELL) $(REFLECTOR)
+
+check-env:
+ifndef TARGET_SHELL
+	$(error Indique el path a una shell mediante la variable de entorno TARGET_SHELL)
+endif
 
 clean:
 	rm reflector
 
-.PHONY: all clean test
+.PHONY: all clean compile-target-shell test
 

--- a/shell/Makefile
+++ b/shell/Makefile
@@ -1,13 +1,22 @@
+TARGET_SHELL_DIR ?=
+
+ifdef TARGET_SHELL_DIR
+TARGET_SHELL = $(TARGET_SHELL_DIR)/sh
+endif
+
 TARGET_SHELL ?=
 REFLECTOR ?= $(abspath ./reflector)
 
 all: reflector
 
 compile-target-shell: check-env
-	$(MAKE) -C $(TARGET_SHELL) clean
-	$(MAKE) -C $(TARGET_SHELL) 
+	$(MAKE) -C $(TARGET_SHELL_DIR) clean
+	$(MAKE) -C $(TARGET_SHELL_DIR) -B -e SHELL_TEST=true
 
-test: check-env reflector compile-target-shell
+test: check-env reflector
+ifdef TARGET_SHELL_DIR
+test: compile-target-shell
+endif
 	./test-shell.py $(TARGET_SHELL) $(REFLECTOR)
 
 check-env:

--- a/shell/README.md
+++ b/shell/README.md
@@ -1,0 +1,137 @@
+# Lab fork
+
+## Ejecución de las pruebas
+
+Las pruebas verifican el comportamiento de la shell implementada enviandole
+comandos y leyendo la salida de los programas que ésta crea. En este sentido, el
+prompt genera problemas al parsear la salida.
+
+Por esta razón es necesario compilar la shell en **modo no interactivo**. Esto
+quire decir que no se ve a imprimir el _prompt_ ni ningún mensaje de
+error/debug.
+
+La shell de la cátedra viene preparada para compilar la shell en modo no
+interactivo. Para eso, limpiar los binarios generados y volver a compilar
+definiendo la variable de entorno `TEST_SHELL`. El procedimiento sería entonces:
+
+```
+# En el directorio donde esté su shell
+make clean
+make -B -e SHELL_TEST=true
+```
+
+**IMPORTANTE**: esto compila la shell en modo no interactivo, al ejecutarlo
+notarán la diferencia. Si quieren volver a la versión original sencillamente
+vuelvan a compilar con `make clean; make`.
+
+### Ejecución nativa
+
+Para ejecutar las pruebas de forma nativa, es necesario instalar las
+dependencias. Deben contar con una versión de `pyton3` instalda, junto con su
+correspondiente `pip3` para poder instalar módulos de Python.
+
+Las únicas dependencias para la ejecución son los módulos de python `[termcolor]` y `[pyyaml]`.
+
+[termcolor]: https://pypi.org/project/termcolor/
+[pyyaml]: https://pyyaml.org/
+
+Para instalarla, alcanza con ejecutar:
+
+```bash
+pip install termcolor
+```
+
+Con las dependencias instaladas, correr las pruebas usando el target de Makefile
+`test`. Es necesario definir, previamente, en una variable de entorno
+(`TARGET_SHELL`) el path completo a su shell compilada en modo no interactivo.
+
+Si la variable `TARGET_SHELL` no está definida correctamente, Makefile arrojará
+un error:
+
+```
+$ make test
+Makefile:8: *** Indique el path a una shell mediante la variable de entorno
+TARGET_SHELL.  Stop.
+```
+
+Para definir la variable, sencillamente se puede agregar como variable temporal
+para este comando; o bien ejecutar una única vez (por terminal) el built-in
+_export_.
+
+```
+# Opción 1: indicar la shell en cada comando
+TARGET_SHELL=/path/a/mi/shell make test
+
+# Opción 2: definir la variable globalmente para la sesión actual
+export TARGET_SHELL=/path/a/mi/shell
+make test
+```
+
+#### Probar que las pruebas están andando
+
+Como las pruebas validan el comportamiento de una shell normal, puede utilizarse
+una shell pre-existente para validar que el entorno de pruebas funciona
+correctamente.
+
+Pueden utilizar `bash` para correr las pruebas.
+
+```
+$ TARGET_SHELL=/bin/bash make test
+./test-shell.py /bin/bash /vagrant/labs/lab-tests/shell/reflector
+Test temp files will be stored in /tmp/tmphjeojw7r-shell-test
+PASS 1/23: Tests that cd . and cd .. works correctly by checking pwd (no prompt)
+(./tests/cd_back.yaml)
+PASS 2/23: Tests that cd works correctly by checking pwd (no prompt)
+(./tests/cd_basic.yaml)
+PASS 3/23: Tests that cd with no arguments takes you home (/proc/sys :D)
+(./tests/cd_home.yaml)
+PASS 4/23: Test that empty variables are not substituted
+(./tests/env_empty_variable.yaml)
+PASS 5/23: Test that large variables are substituted properly
+(./tests/env_large_variable.yaml)
+PASS 6/23: Test that magic variable $? works properly
+(./tests/env_magic_variable.yaml)
+PASS 7/23: Test simple variable substitution (./tests/env_substitution.yaml)
+PASS 8/23: Test that unset variables are not substituted
+(./tests/env_unset_variable.yaml)
+PASS 9/23: Tests that child proceses exit if execve fails
+(./tests/execve_exits_if_failed.yaml)
+PASS 10/23: Test that consecutive pipes do not leak file descritors into the
+executed command. (./tests/pipes_does_not_leak_fds.yaml)
+PASS 11/23: Tests that the shell properly waits to the left child
+(./tests/pipes_wait_left_child.yaml)
+PASS 12/23: Tests that the shell properly waits to the right child
+(./tests/pipes_wait_right_child.yaml)
+PASS 13/23: Tests that redirecting stdin from a non-existing file does not
+create an empty file. (./tests/redirect_does_not_create.yaml)
+PASS 14/23: Test that redirects do not leak file descritors into the executed
+command. (./tests/redirect_does_not_leak_fds.yaml)
+PASS 15/23: Tests that a failed redirect prevents the command from executing
+(./tests/redirect_dont_execve_if_failed.yaml)
+PASS 16/23: Tests that redirecting stderr works as expected
+(./tests/redirect_stderr.yaml)
+PASS 17/23: Tests that stderr to stdout (2>&1) redirection works as expected
+(./tests/redirect_stderr_to_stdout.yaml)
+PASS 18/23: Tests that redirecting stdin works as expected
+(./tests/redirect_stdin.yaml)
+PASS 19/23: Tests that redirecting stdout works as expected
+(./tests/redirect_stdout.yaml)
+PASS 20/23: Tests that redirecting stdout works as expected
+(./tests/redirect_stdout_trunc.yaml)
+PASS 21/23: Test simple echo command (./tests/simple_echo.yaml)
+PASS 22/23: Test simple env variable (./tests/simple_env.yaml)
+PASS 23/23: Test exit built-in (./tests/simple_exit.yaml)
+23 out of 23 tests passed
+```
+
+**DISCLAIMER**: estas pruebas están en versión beta y es posible que tengan
+bugs/errores. Solo las probamos con `/bin/bash`, otras terminales podrían tener
+fallas. Si encuentran un error, avisenos!
+
+## Docker
+
+También existe la posibilidad de utilizar [Docker](https://docs.docker.com/engine/install/) para correr las pruebas. Alcanza con ejecutar:
+
+```bash
+./run labpath
+```

--- a/shell/README.md
+++ b/shell/README.md
@@ -1,13 +1,13 @@
-# Lab fork
+# Pruebas para el lab shell
 
 ## Ejecución de las pruebas
 
-Las pruebas verifican el comportamiento de la shell implementada enviandole
+Las pruebas verifican el comportamiento de la shell implementada enviándole
 comandos y leyendo la salida de los programas que ésta crea. En este sentido, el
 prompt genera problemas al parsear la salida.
 
 Por esta razón es necesario compilar la shell en **modo no interactivo**. Esto
-quire decir que no se ve a imprimir el _prompt_ ni ningún mensaje de
+quiere decir que no se ve a imprimir el _prompt_ ni ningún mensaje de
 error/debug.
 
 La shell de la cátedra viene preparada para compilar la shell en modo no
@@ -27,7 +27,7 @@ vuelvan a compilar con `make clean; make`.
 ### Ejecución nativa
 
 Para ejecutar las pruebas de forma nativa, es necesario instalar las
-dependencias. Deben contar con una versión de `pyton3` instalda, junto con su
+dependencias. Deben contar con una versión de `python3` instalada, junto con su
 correspondiente `pip3` para poder instalar módulos de Python.
 
 Las únicas dependencias para la ejecución son los módulos de python `[termcolor]` y `[pyyaml]`.
@@ -60,10 +60,10 @@ _export_.
 
 ```
 # Opción 1: indicar la shell en cada comando
-TARGET_SHELL=/path/a/mi/shell make test
+TARGET_SHELL=/path/al/directorio/de/mi/shell make test
 
 # Opción 2: definir la variable globalmente para la sesión actual
-export TARGET_SHELL=/path/a/mi/shell
+export TARGET_SHELL=/path/al/directorio/de/mi/shell
 make test
 ```
 
@@ -124,14 +124,20 @@ PASS 23/23: Test exit built-in (./tests/simple_exit.yaml)
 23 out of 23 tests passed
 ```
 
-**DISCLAIMER**: estas pruebas están en versión beta y es posible que tengan
+**IMPORTANTE**: estas pruebas están en versión beta y es posible que tengan
 bugs/errores. Solo las probamos con `/bin/bash`, otras terminales podrían tener
-fallas. Si encuentran un error, avisenos!
+fallas. Si encuentran un error, avísenos!
 
 ## Docker
 
 También existe la posibilidad de utilizar [Docker](https://docs.docker.com/engine/install/) para correr las pruebas. Alcanza con ejecutar:
 
 ```bash
-./run labpath
+./run /path/al/directorio/de/mi/shell
 ```
+
+**IMPORTANTE**: El código que corre el contenedor va a ejecutar `make clean;
+make -B -e TEST_SHELL=true` que se indicó más arriba, con lo cual va a
+**modificar el directorio de su shell** tal y como si hubieran ejecutado esos
+comandos. Esto no es un problema pero es algo a tener en cuenta.
+

--- a/shell/run
+++ b/shell/run
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+if [[ $# == 0 ]]; then
+	echo "labpath is required"
+	exit 1
+fi;
+
+LAB_PATH=$1
+shift
+
+docker build -t test-shell-runner -f Dockerfile .
+docker run -v $LAB_PATH:/shell/lab-to-test test-shell-runner make test

--- a/shell/test-shell.py
+++ b/shell/test-shell.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3 
+#! /usr/bin/env python3
 import os
 import shutil
 import sys
@@ -104,12 +104,14 @@ def run_tests(shell_binary: str, reflector_aux: str):
     count = 1
     failed = 0
     total = len(tests)
-    for test in tests:
+    for test_path in tests:
+        test = ShellTest(test_path, subs_map)
         try:
-            custom_test(subs_map, test)
-            cprint("PASS {}/{}: {}".format(count, total, test), "green")
+            test.run()
+            # custom_test(subs_map, test)
+            cprint("PASS {}/{}: {} ({})".format(count, total, test.description, test_path), "green")
         except Exception as e:
-            cprint("FAIL {}/{}: {}. Exception ocurred: {}".format(count, total, test, e), "red")
+            cprint("FAIL {}/{}: {} ({}). Exception ocurred: {}".format(count, total, test.description, test_path, e), "red")
             failed += 1
         finally:
             count += 1

--- a/shell/test-shell.py
+++ b/shell/test-shell.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#! /usr/bin/python3
 import os
 import shutil
 import sys


### PR DESCRIPTION
# Cambios

* Agrego README a las pruebas del shell 😅 
* Agrego Dockerfile para las pruebas del shell
  * Basado en `ubuntu:20.04` corriendo `python3.8`
* Modifico el script de pruebas para que imprima la descripción en lugar de solo el path.
* Modifico Makefile para que admita un directorio en lugar de un binario e intente compilar la shell (todavía se puede correr a mano pasando el binario ya compilado)
  * Usar `TARGET_SHELL_DIR` para compilar la shell (se asume el archivo final será `${TARGET_SHELL_DIR}/sh`
  * Usar `TARGET_SHELL` para utilizar una shell compilada (se puede probar con `/bin/bash`!)
 * Modifico el nombre de la imagen del lab-fork para que no choquen los nombres

## Nuevo formato de la salida
```
$ TARGET_SHELL=/bin/bash make test
./test-shell.py /bin/bash /vagrant/labs/lab-tests/shell/reflector
Test temp files will be stored in /tmp/tmpf6t_4pag-shell-test
PASS 1/23: Tests that cd . and cd .. works correctly by checking pwd (no prompt) (./tests/cd_back.yaml)
PASS 2/23: Tests that cd works correctly by checking pwd (no prompt) (./tests/cd_basic.yaml)
PASS 3/23: Tests that cd with no arguments takes you home (/proc/sys :D) (./tests/cd_home.yaml)
PASS 4/23: Test that empty variables are not substituted (./tests/env_empty_variable.yaml)
PASS 5/23: Test that large variables are substituted properly (./tests/env_large_variable.yaml)
PASS 6/23: Test that magic variable $? works properly (./tests/env_magic_variable.yaml)
PASS 7/23: Test simple variable substitution (./tests/env_substitution.yaml)
PASS 8/23: Test that unset variables are not substituted (./tests/env_unset_variable.yaml)
PASS 9/23: Tests that child proceses exit if execve fails (./tests/execve_exits_if_failed.yaml)
PASS 10/23: Test that consecutive pipes do not leak file descritors into the executed command. (./tests/pipes_does_not_leak_fds.yaml)
PASS 11/23: Tests that the shell properly waits to the left child (./tests/pipes_wait_left_child.yaml)
PASS 12/23: Tests that the shell properly waits to the right child (./tests/pipes_wait_right_child.yaml)
PASS 13/23: Tests that redirecting stdin from a non-existing file does not create an empty file. (./tests/redirect_does_not_create.yaml)
PASS 14/23: Test that redirects do not leak file descritors into the executed command. (./tests/redirect_does_not_leak_fds.yaml)
PASS 15/23: Tests that a failed redirect prevents the command from executing (./tests/redirect_dont_execve_if_failed.yaml)
PASS 16/23: Tests that redirecting stderr works as expected (./tests/redirect_stderr.yaml)
PASS 17/23: Tests that stderr to stdout (2>&1) redirection works as expected (./tests/redirect_stderr_to_stdout.yaml)
PASS 18/23: Tests that redirecting stdin works as expected (./tests/redirect_stdin.yaml)
PASS 19/23: Tests that redirecting stdout works as expected (./tests/redirect_stdout.yaml)
PASS 20/23: Tests that redirecting stdout works as expected (./tests/redirect_stdout_trunc.yaml)
PASS 21/23: Test simple echo command (./tests/simple_echo.yaml)
PASS 22/23: Test simple env variable (./tests/simple_env.yaml)
PASS 23/23: Test exit built-in (./tests/simple_exit.yaml)
23 out of 23 tests passed
```

-JM