### PR TITLE
Minor adjustments to reflector

### DIFF
--- a/shell/reflector.c
+++ b/shell/reflector.c
@@ -1,3 +1,4 @@
+#define _POSIX_C_SOURCE 200809L
 #include <stdio.h>
 #include <stdlib.h>
 #include <dirent.h>
@@ -8,26 +9,23 @@
 #include <string.h>
 
 int inspect_fds(int out_fd) {
-    char procdir[100];
-
-    int res = sprintf(procdir, "/proc/%d/fd", getpid());
-
-    DIR* dir = opendir(procdir);
+    DIR* dir = opendir("/proc/self/fd");
     int dir_fd = dirfd(dir);
-
     struct dirent* entry;
+
     while ((entry = readdir(dir))) {
         if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, "..")) {
             continue;
         }
 
-        char target_link_buf[100];
-        int len = readlinkat(dir_fd, entry->d_name, target_link_buf, 100);
-        target_link_buf[len] = 0;
-
         if (dir_fd == atoi(entry->d_name) || out_fd == atoi(entry->d_name)) {
             continue;
         }
+
+        char target_link_buf[100];
+        ssize_t len = readlinkat(dir_fd, entry->d_name, target_link_buf, 100);
+        target_link_buf[len] = 0;
+
         // if (!strcmp(target_link_buf, procdir)) {
         //    continue;
         //}


### PR DESCRIPTION
- use `/proc/self/fd` to avoid sprintf over getpid()
- correct `ssize_t` return type for readlinkat()
- move own-fd check before readlinkat()